### PR TITLE
Stencils: indexing revamp

### DIFF
--- a/schism/finite_differences/substitution.py
+++ b/schism/finite_differences/substitution.py
@@ -60,14 +60,12 @@ class Substitution:
         Get the stencils by generating the required Interpolant and Projection
         objects
         """
-        time = self.deriv.expr.indices[0]
         ndims = len(self.geometry.grid.dimensions)
         radius_map = {func: func.space_order//2 for func in self.basis_map}
         support = SupportRegion(self.basis_map, radius_map)
         interpolant = Interpolant(support, self.group,
                                   self.basis_map, self.skin.geometry,
-                                  self.skin.points,
-                                  time=time)
+                                  self.skin.points)
         projection = Projection(self.deriv, self.group, self.basis_map)
 
         # Loop whilst there are points which don't yet have stencils
@@ -88,8 +86,7 @@ class Substitution:
                 interpolant = Interpolant(support, self.group,
                                           self.basis_map,
                                           self.skin.geometry,
-                                          masked_points,
-                                          time=time)
+                                          masked_points)
 
             elif self.strategy == 'reduce':
                 basis_map = {func: interpolant.basis_map[func].reduce_order(2)
@@ -97,8 +94,7 @@ class Substitution:
                 interpolant = Interpolant(support, self.group,
                                           basis_map,
                                           self.skin.geometry,
-                                          masked_points,
-                                          time=time)
+                                          masked_points)
                 projection = Projection(self.deriv, self.group, basis_map)
 
             else:
@@ -136,10 +132,14 @@ class Substitution:
         weight_map = {}
         data_map = {item: np.zeros(grid.shape) for item in rhs[rhs_nonzero]}
         for item in rhs[rhs_nonzero]:
-            if isinstance(item, dv.types.Indexed):
-                indices = [int((item.indices[1+d]
-                               - dims[d]).as_coeff_Mul()[0])
-                           for d in range(ndims)]
+            # Check that the RHS is a Devito Function
+            if isinstance(item, dv.Function):
+                # Turn the offset in space into a tag
+                # First reduce f(t, x+h_x, y-h_y) to [1, -1]
+                indices = [(ind-f_ind).as_type_Mul()[0] for dim, ind, f_ind
+                           in zip(item.dimensions, item.indices,
+                                  item.function.indices)
+                           if dim.is_Space]
                 underscores = ['_' for d in range(ndims)]
                 indices_str = [str(i) for i in indices]
                 index = list(chain(*zip(underscores, indices_str)))
@@ -180,7 +180,6 @@ class Substitution:
         interior_stencil = get_sten_vector(self.deriv, footprint)
 
         expr = self.deriv.expr
-        t = expr.indices[0].subs(expr.time_dim.spacing, 1)
         dims = expr.space_dimensions
 
         # Needs to use the interior mask of the target subgrid
@@ -193,12 +192,12 @@ class Substitution:
                 deriv_stagger.append(sp.core.numbers.Zero())
         origin = tuple(deriv_stagger)
 
-        for i in range(footprint.shape[-1]):
-            ind = footprint[:, i]
-            func_index = (t,) + tuple([dims[i]+ind[i]
-                                       for i in range(len(dims))])
-            wdata = self.data_map[expr[func_index]]
-            wdata[self.geometry.interior_mask[origin]] = interior_stencil[i]
+        # P for stencil point, d for dimension
+        for p in range(len(footprint[0])):
+            ind_subs = {dims[d]: dims[d] + footprint[d][p]*dims[d].spacing
+                        for d in range(len(dims))}
+            wdata = self.data_map[expr.subs(ind_subs)]
+            wdata[self.geometry.interior_mask[origin]] = interior_stencil[p]
 
     def _fill_modified_weights(self):
         """Fill the weight functions with the modified weights"""
@@ -241,11 +240,12 @@ class Substitution:
         denom = reduce(lambda a, b: a*b, denom_args)
         # Get the numerator
         # Multiply each weight by its corresponding expression
-        num_args = [w*f for w, f in zip(self.weight_map.keys(),
-                                        self.weight_map.values())]
-        num = sum(num_args)
-        # Combine them
-        expr = num/denom
+        # Divide by denom here to better resemble devito-generated stencils
+        args = [w*f/denom for w, f in zip(self.weight_map.keys(),
+                                          self.weight_map.values())]
+        # Creation of EvalDerivative here enable optimization down the line
+        # The derivative is of self.deriv.expr
+        expr = dv.EvalDerivative(*args, base=self.deriv.expr)
         # Set self.expr
         self._expr = expr
 

--- a/tests/test_boundary.py
+++ b/tests/test_boundary.py
@@ -132,7 +132,7 @@ class TestSubstitutions:
 
         t = f.time_dim
 
-        current = subs[f.dy2].subs(t, t+1)
+        current = subs[f.dy2].subs(t, t+t.spacing)
         forward = subs[f.forward.dy2]
 
         assert str(current) == str(forward)

--- a/tests/test_interpolation.py
+++ b/tests/test_interpolation.py
@@ -189,15 +189,16 @@ class TestInterpolant:
             check_len = nfuncs*(s_o+1)
         assert len(interpolant.interior_vector) == check_len
 
-    answers = ['[f0[t, x - 1] f0[t, x] f0[t, x + 1]]',
-               '[f0[t, x - 1] f0[t, x] f0[t, x + 1] f1[t, x - 1] '
-               + 'f1[t, x] f1[t, x + 1]]',
-               '[f0[t, x - 1, y - 1] f0[t, x - 1, y] f0[t, x - 1, y + 1] '
-               + 'f0[t, x, y - 1]\n f0[t, x, y] f0[t, x, y + 1] '
-               + 'f0[t, x + 1, y - 1] f0[t, x + 1, y]\n f0[t, x + 1, y + 1]]',
-               '[f0[t, x - 1, y] f0[t, x, y] f0[t, x + 1, y]]',
-               '[f0[t, x, y - 1] f0[t, x, y] f0[t, x, y + 1]]',
-               '[f0[t, x - 1, y, z] f0[t, x, y, z] f0[t, x + 1, y, z]]']
+    answers = ['[f0(t, x - h_x) f0(t, x) f0(t, x + h_x)]',
+               '[f0(t, x - h_x) f0(t, x) f0(t, x + h_x) f1(t, x - h_x) '
+               + 'f1(t, x)\n f1(t, x + h_x)]',
+               '[f0(t, x - h_x, y - h_y) f0(t, x - h_x, y) '
+               + 'f0(t, x - h_x, y + h_y)\n f0(t, x, y - h_y) f0(t, x, y) '
+               + 'f0(t, x, y + h_y) f0(t, x + h_x, y - h_y)\n '
+               + 'f0(t, x + h_x, y) f0(t, x + h_x, y + h_y)]',
+               '[f0(t, x - h_x, y) f0(t, x, y) f0(t, x + h_x, y)]',
+               '[f0(t, x, y - h_y) f0(t, x, y) f0(t, x, y + h_y)]',
+               '[f0(t, x - h_x, y, z) f0(t, x, y, z) f0(t, x + h_x, y, z)]']
 
     @pytest.mark.parametrize('ndims, basis_dim, nfuncs, ans',
                              [(1, None, 1, answers[0]),
@@ -245,8 +246,6 @@ class TestInterpolant:
         # Create the Interpolant
         interpolant = Interpolant(support, group, basis_map,
                                   skin.geometry, skin.points)
-
-        print(interpolant.interior_vector)
 
         # Check the interior vector matches the answer
         assert str(interpolant.interior_vector) == ans

--- a/tests/test_substitution.py
+++ b/tests/test_substitution.py
@@ -232,26 +232,27 @@ class TestSubstitution:
     def test_returned_expr(self):
         """Check that the correct expression is returned"""
         subs = weights_test_setup()
-        ans = '(w_f_dy2_0_0(x, y)*f[t, x, y] ' \
-            + '+ w_f_dy2_0_1(x, y)*f[t, x, y + 1] ' \
-            + '+ w_f_dy2_0_2(x, y)*f[t, x, y + 2] ' \
-            + '+ w_f_dy2_0_m1(x, y)*f[t, x, y - 1] ' \
-            + '+ w_f_dy2_0_m2(x, y)*f[t, x, y - 2] ' \
-            + '+ w_f_dy2_1_0(x, y)*f[t, x + 1, y] ' \
-            + '+ w_f_dy2_1_1(x, y)*f[t, x + 1, y + 1] ' \
-            + '+ w_f_dy2_1_2(x, y)*f[t, x + 1, y + 2] ' \
-            + '+ w_f_dy2_1_m1(x, y)*f[t, x + 1, y - 1] ' \
-            + '+ w_f_dy2_1_m2(x, y)*f[t, x + 1, y - 2] ' \
-            + '+ w_f_dy2_2_0(x, y)*f[t, x + 2, y] ' \
-            + '+ w_f_dy2_2_1(x, y)*f[t, x + 2, y + 1] ' \
-            + '+ w_f_dy2_2_m1(x, y)*f[t, x + 2, y - 1] ' \
-            + '+ w_f_dy2_m1_0(x, y)*f[t, x - 1, y] ' \
-            + '+ w_f_dy2_m1_1(x, y)*f[t, x - 1, y + 1] ' \
-            + '+ w_f_dy2_m1_2(x, y)*f[t, x - 1, y + 2] ' \
-            + '+ w_f_dy2_m1_m1(x, y)*f[t, x - 1, y - 1] ' \
-            + '+ w_f_dy2_m1_m2(x, y)*f[t, x - 1, y - 2] ' \
-            + '+ w_f_dy2_m2_0(x, y)*f[t, x - 2, y] ' \
-            + '+ w_f_dy2_m2_1(x, y)*f[t, x - 2, y + 1] ' \
-            + '+ w_f_dy2_m2_m1(x, y)*f[t, x - 2, y - 1])/h_y**2'
+        ans = 'f(t, x, y)*w_f_dy2_0_0(x, y)/h_y**2 ' \
+            + '+ f(t, x, y - 2*h_y)*w_f_dy2_0_m2(x, y)/h_y**2 ' \
+            + '+ f(t, x, y - h_y)*w_f_dy2_0_m1(x, y)/h_y**2 ' \
+            + '+ f(t, x, y + h_y)*w_f_dy2_0_1(x, y)/h_y**2 ' \
+            + '+ f(t, x, y + 2*h_y)*w_f_dy2_0_2(x, y)/h_y**2 ' \
+            + '+ f(t, x - 2*h_x, y)*w_f_dy2_m2_0(x, y)/h_y**2 ' \
+            + '+ f(t, x - 2*h_x, y - h_y)*w_f_dy2_m2_m1(x, y)/h_y**2 ' \
+            + '+ f(t, x - 2*h_x, y + h_y)*w_f_dy2_m2_1(x, y)/h_y**2 ' \
+            + '+ f(t, x - h_x, y)*w_f_dy2_m1_0(x, y)/h_y**2 ' \
+            + '+ f(t, x - h_x, y - 2*h_y)*w_f_dy2_m1_m2(x, y)/h_y**2 ' \
+            + '+ f(t, x - h_x, y - h_y)*w_f_dy2_m1_m1(x, y)/h_y**2 ' \
+            + '+ f(t, x - h_x, y + h_y)*w_f_dy2_m1_1(x, y)/h_y**2 ' \
+            + '+ f(t, x - h_x, y + 2*h_y)*w_f_dy2_m1_2(x, y)/h_y**2 ' \
+            + '+ f(t, x + h_x, y)*w_f_dy2_1_0(x, y)/h_y**2 ' \
+            + '+ f(t, x + h_x, y - 2*h_y)*w_f_dy2_1_m2(x, y)/h_y**2 ' \
+            + '+ f(t, x + h_x, y - h_y)*w_f_dy2_1_m1(x, y)/h_y**2 ' \
+            + '+ f(t, x + h_x, y + h_y)*w_f_dy2_1_1(x, y)/h_y**2 ' \
+            + '+ f(t, x + h_x, y + 2*h_y)*w_f_dy2_1_2(x, y)/h_y**2 ' \
+            + '+ f(t, x + 2*h_x, y)*w_f_dy2_2_0(x, y)/h_y**2 ' \
+            + '+ f(t, x + 2*h_x, y - h_y)*w_f_dy2_2_m1(x, y)/h_y**2 ' \
+            + '+ f(t, x + 2*h_x, y + h_y)*w_f_dy2_2_1(x, y)/h_y**2'
 
+        print(subs.expr)
         assert str(subs.expr) == ans

--- a/tests/test_substitution.py
+++ b/tests/test_substitution.py
@@ -254,5 +254,4 @@ class TestSubstitution:
             + '+ f(t, x + 2*h_x, y - h_y)*w_f_dy2_2_m1(x, y)/h_y**2 ' \
             + '+ f(t, x + 2*h_x, y + h_y)*w_f_dy2_2_1(x, y)/h_y**2'
 
-        print(subs.expr)
         assert str(subs.expr) == ans


### PR DESCRIPTION
Stencils previously used unsafe index notation. This led to additional unnecessary infrastructure and poor comprehension by the Devito compiler leading to slow runtimes and long compile times. Now substitution is used and an EvalDerivative is formed instead.