### PR TITLE
Fixed cross-derivative stencils

### DIFF
--- a/schism/finite_differences/interpolate_project.py
+++ b/schism/finite_differences/interpolate_project.py
@@ -265,6 +265,13 @@ class Interpolant:
             boundary_msk[in_bounds] = self.geometry.boundary_mask[pts_ib]
 
         # (0 axis is support region points)
+        # Check if func is the derivative function
+        # If so, then extrapolant mask will need applying
+        # Logical and with the boundary mask
+        if func is self.support.deriv.expr:
+            extrapolant_msk = self.support.extrapolant_mask[:, np.newaxis]
+            boundary_msk = np.logical_and(extrapolant_msk,
+                                          boundary_msk)
         self._boundary_mask = boundary_msk
 
     def _get_boundary_matrices(self):

--- a/schism/finite_differences/interpolate_project.py
+++ b/schism/finite_differences/interpolate_project.py
@@ -178,7 +178,16 @@ class Interpolant:
             # Support points with stagger
             s_p = tuple([self.support.footprint_map[func][dim] + stagger[dim]
                          for dim in range(len(func.space_dimensions))])
-            submats.append(row_func(*s_p))
+
+            submat = row_func(*s_p)
+            # Only need to apply this mask to submatric for the
+            # field on which derivatives are being taken.
+            if func is self.support.deriv.expr:
+                # Mask for points not in extrapolant
+                mask = np.logical_not(self.support.extrapolant_mask)
+                # Not used in extrapolant, zero these rows
+                submat[:, mask] = 0.
+            submats.append(submat)
         # Will need to do an axis swap in due course
         self._interior_matrix = np.concatenate(submats, axis=1)
 

--- a/schism/finite_differences/substitution.py
+++ b/schism/finite_differences/substitution.py
@@ -41,8 +41,17 @@ class Substitution:
         self._skin = skin
         self._geometry = self.skin.geometry
 
-        self._setup_collections()
-        self._get_stencils()
+        # Check the number of points in the skin here
+        # Then generate normal stencils with some zero weights
+        # Will want to skip _setup_collections and _get_stencils
+        # _setup_weight_funcs will want to behave differently
+        # _fill_weight_funcs will want to only fill standard weights
+
+        # Only need to generate boundary operators if there are
+        # points in the skin to modify
+        if self.skin.npts > 0:
+            self._setup_collections()
+            self._get_stencils()
         self._setup_weight_funcs()
         self._fill_weight_funcs()
         self._form_expression()
@@ -125,10 +134,34 @@ class Substitution:
         deriv_tag = ''.join([d.name+str(o)
                              for d, o in zip(deriv_dims, deriv_order)])
 
-        # Get the interpolant with the largest support region
-        interp = self.interpolants.largest_support
-        rhs = interp.vector
-        rhs_nonzero = rhs != 0
+        # If interpolants have been created, then use the RHS
+        # with the largest support region
+        # Best to check the number of points in the skin
+        if self.skin.npts > 0:
+            # Get the interpolant with the largest support region
+            interp = self.interpolants.largest_support
+            rhs = interp.vector
+            rhs_nonzero = rhs != 0
+            # Points used in the modified stencils
+            sten_points = rhs[rhs_nonzero]
+        else:
+            # Interpolants have not been created
+            expr = self.deriv.expr
+            dims = expr.space_dimensions
+            # Need to get the stencil footprint
+            footprint = stencil_footprint(self.deriv)
+            # Create a term for each point in this
+            # P for stencil point, d for dimension
+            rhs = []
+            for p in range(len(footprint[0])):
+                ind_subs = {dims[d]: dims[d]
+                            + footprint[d][p]*dims[d].spacing
+                            for d in range(len(dims))}
+
+                rhs.append(expr.subs(ind_subs))
+            # Form into a numpy array
+            # Output as sten_points
+            sten_points = np.array(rhs)
 
         grid = self.geometry.grid
         dims = grid.dimensions
@@ -136,13 +169,8 @@ class Substitution:
 
         wfuncs = []
         weight_map = {}
-
-        # Need to get positions in the stencil that are not in rhs_nonzero
-        # Generate an entry for the footprint, then intersect the sets
-        print(rhs[rhs_nonzero])
-        print(stencil_footprint(self.deriv))
-        data_map = {item: np.zeros(grid.shape) for item in rhs[rhs_nonzero]}
-        for item in rhs[rhs_nonzero]:
+        data_map = {item: np.zeros(grid.shape) for item in sten_points}
+        for item in sten_points:
             # Check that the RHS is a Devito Function
             if isinstance(item, dv.Function):
                 # Turn the offset in space into a tag
@@ -168,7 +196,6 @@ class Substitution:
             else:
                 raise NotImplementedError("Non-Function RHS not implemented")
 
-        self._wfuncs = tuple(wfuncs)
         self._data_map = frozendict(data_map)
         self._weight_map = frozendict(weight_map)
 
@@ -178,7 +205,9 @@ class Substitution:
         respective coefficients.
         """
         self._fill_standard_weights()
-        self._fill_modified_weights()
+        # Only fill modified weights if boundary operators required
+        if self.skin.npts > 0:
+            self._fill_modified_weights()
 
         # Fill weight data from data arrays
         # Can't currently directly fill them due to bug when indexing function
@@ -196,33 +225,31 @@ class Substitution:
 
         expr = self.deriv.expr
         dims = expr.space_dimensions
+        grid = self.geometry.grid
 
         # Needs to use the interior mask of the target subgrid
+        # Subgrid targeting needs to use current subgrid offset where
+        # information is not present in the derivative.
+        func_origin = {dim: origin
+                       for dim, origin in zip(self.deriv.expr.dimensions,
+                                              self.deriv.expr.origin)}
         deriv_stagger = []
         for d in range(len(expr.space_dimensions)):
             try:
                 deriv_stagger.append(self.deriv.x0[expr.space_dimensions[d]]
                                      - expr.space_dimensions[d])
             except KeyError:
-                deriv_stagger.append(sp.core.numbers.Zero())
+                # If no info in derivative, use the info of the grid
+                # which the function is discretized onto.
+                deriv_stagger.append(func_origin[grid.dimensions[d]])
         origin = tuple(deriv_stagger)
-
-        print(self.deriv)
-        print(expr)
-        for key, val in self.data_map.items():
-            print(key)
 
         # P for stencil point, d for dimension
         for p in range(len(footprint[0])):
             ind_subs = {dims[d]: dims[d] + footprint[d][p]*dims[d].spacing
                         for d in range(len(dims))}
 
-            print(ind_subs)
-            print(expr.subs(ind_subs))
-            print()
             wdata = self.data_map[expr.subs(ind_subs)]
-            # Need to add additional functions here as needed
-            # Should this be done on the fly or can it be spotted early?
             wdata[self.geometry.interior_mask[origin]] = interior_stencil[p]
 
     def _fill_modified_weights(self):
@@ -332,11 +359,6 @@ class Substitution:
     def projections(self):
         """The collection of Projection objects"""
         return self._projections
-
-    @property
-    def wfuncs(self):
-        """The weight functions"""
-        return self._wfuncs
 
     @property
     def weight_map(self):

--- a/schism/finite_differences/substitution.py
+++ b/schism/finite_differences/substitution.py
@@ -136,6 +136,11 @@ class Substitution:
 
         wfuncs = []
         weight_map = {}
+
+        # Need to get positions in the stencil that are not in rhs_nonzero
+        # Generate an entry for the footprint, then intersect the sets
+        print(rhs[rhs_nonzero])
+        print(stencil_footprint(self.deriv))
         data_map = {item: np.zeros(grid.shape) for item in rhs[rhs_nonzero]}
         for item in rhs[rhs_nonzero]:
             # Check that the RHS is a Devito Function
@@ -202,12 +207,22 @@ class Substitution:
                 deriv_stagger.append(sp.core.numbers.Zero())
         origin = tuple(deriv_stagger)
 
+        print(self.deriv)
+        print(expr)
+        for key, val in self.data_map.items():
+            print(key)
+
         # P for stencil point, d for dimension
         for p in range(len(footprint[0])):
             ind_subs = {dims[d]: dims[d] + footprint[d][p]*dims[d].spacing
                         for d in range(len(dims))}
 
+            print(ind_subs)
+            print(expr.subs(ind_subs))
+            print()
             wdata = self.data_map[expr.subs(ind_subs)]
+            # Need to add additional functions here as needed
+            # Should this be done on the fly or can it be spotted early?
             wdata[self.geometry.interior_mask[origin]] = interior_stencil[p]
 
     def _fill_modified_weights(self):

--- a/schism/finite_differences/substitution.py
+++ b/schism/finite_differences/substitution.py
@@ -77,7 +77,7 @@ class Substitution:
             time = None
         ndims = len(self.geometry.grid.dimensions)
         radius_map = {func: func.space_order//2 for func in self.basis_map}
-        support = SupportRegion(self.basis_map, radius_map)
+        support = SupportRegion(self.basis_map, radius_map, self.deriv)
         interpolant = Interpolant(support, self.group,
                                   self.basis_map, self.skin.geometry,
                                   self.skin.points, time=time)

--- a/schism/geometry/skin.py
+++ b/schism/geometry/skin.py
@@ -1,7 +1,6 @@
 """Geometry for the skin of modified operators surrounding the boundary"""
 
 import numpy as np
-import sympy as sp
 
 
 def stencil_footprint(deriv):
@@ -69,13 +68,20 @@ class ModifiedSkin:
         all_points = tuple([mp[i] for i in range(mp.shape[0])])
 
         # Needs to use the interior mask of the target subgrid
+        # Subgrid targeting needs to use current subgrid offset where
+        # information is not present in the derivative.
+        func_origin = {dim: origin
+                       for dim, origin in zip(self.deriv.expr.dimensions,
+                                              self.deriv.expr.origin)}
         deriv_stagger = []
         for d in range(len(grid.dimensions)):
             try:
                 deriv_stagger.append(self.deriv.x0[grid.dimensions[d]]
                                      - grid.dimensions[d])
             except KeyError:
-                deriv_stagger.append(sp.core.numbers.Zero())
+                # If no info in derivative, use the info of the grid
+                # which the function is discretized onto.
+                deriv_stagger.append(func_origin[grid.dimensions[d]])
         origin = tuple(deriv_stagger)
 
         interior_mask = self.geometry.interior_mask[origin][all_points]

--- a/schism/geometry/support_region.py
+++ b/schism/geometry/support_region.py
@@ -130,7 +130,7 @@ class SupportRegion:
                                               footprints[func])
                 footprints[func] = union
                 self._extrapolant_mask = mask
-            npts_map[func] = footprint[0].shape[0]
+            npts_map[func] = footprints[func][0].shape[0]
         self._footprint_map = frozendict(footprints)
         self._npts_map = frozendict(npts_map)
 

--- a/schism/geometry/support_region.py
+++ b/schism/geometry/support_region.py
@@ -74,6 +74,10 @@ class SupportRegion:
         Mapping between functions and the radius of their basis. Note that this
         is not a true radius, so much as a convenient measure of extent
         measured in grid increments.
+    deriv : Derivative
+        The derivative of the underlying stencil. Used to ensure that
+        the resultant support region is the union of extrapolant and
+        interior stencils.
 
     Attributes
     ----------
@@ -189,7 +193,7 @@ class SupportRegion:
         """
         new_radius_map = {func: rad + inc
                           for func, rad in self.radius_map.items()}
-        return self.__class__(self.basis_map, new_radius_map)
+        return self.__class__(self.basis_map, new_radius_map, self.deriv)
 
     @property
     def basis_map(self):

--- a/schism/geometry/support_region.py
+++ b/schism/geometry/support_region.py
@@ -170,7 +170,7 @@ class SupportRegion:
             else:  # No offset in other dimensions
                 footprint.append(np.zeros(1+2*radius, dtype=int))
         return tuple(footprint)
-    
+
     def _get_base_support(self):
         """Get the footprint of the interior stencil"""
         footprint = stencil_footprint(self.deriv)

--- a/schism/geometry/support_region.py
+++ b/schism/geometry/support_region.py
@@ -129,7 +129,7 @@ class SupportRegion:
                 union, mask = footprint_union(base_footprint,
                                               footprints[func])
                 footprints[func] = union
-                # TODO: need to store mask somewhere for later use
+                self._extrapolant_mask = mask
             npts_map[func] = footprint[0].shape[0]
         self._footprint_map = frozendict(footprints)
         self._npts_map = frozendict(npts_map)
@@ -227,3 +227,11 @@ class SupportRegion:
         Footprint of the underlying derivative stencil. Used when i
         """
         return self._deriv
+
+    @property
+    def extrapolant_mask(self):
+        """
+        Return the mask limiting the footprint in the field on which the
+        derivative is taken to that of the extrapolation support region.
+        """
+        return self._extrapolant_mask

--- a/tests/test_interpolation.py
+++ b/tests/test_interpolation.py
@@ -115,7 +115,8 @@ def mask_test_setup(setup, func_type):
     radius_map = {func: 1 for func in group.funcs}
 
     # Create a SupportRegion
-    support = SupportRegion(basis_map, radius_map)
+    deriv = f.dx
+    support = SupportRegion(basis_map, radius_map, deriv)
 
     geometry, skin = setup_geom(setup, grid)
 
@@ -154,14 +155,16 @@ class TestInterpolant:
         if basis_dim is None:
             basis_map = {func: Basis(func.name, grid.dimensions, s_o)
                          for func in funcs}
+            deriv = dv.Derivative(funcs[0], grid.dimensions[0])
         else:
             basis_map = {func: Basis(func.name,
                                      (grid.dimensions[basis_dim],),
                                      s_o)
                          for func in funcs}
+            deriv = dv.Derivative(funcs[0], grid.dimensions[basis_dim])
         radius_map = {func: int(s_o//2) for func in funcs}
         # Create a SupportRegion
-        support = SupportRegion(basis_map, radius_map)
+        support = SupportRegion(basis_map, radius_map, deriv)
 
         geometry = DummyGeometry(grid=grid,
                                  interior_mask={origin:
@@ -219,16 +222,18 @@ class TestInterpolant:
         conditions = tuple([SingleCondition(dv.Eq(func, 0)) for func in funcs])
         group = DummyGroup(tuple(funcs), conditions)
         if basis_dim is None:
+            deriv = dv.Derivative(funcs[0], grid.dimensions[0])
             basis_map = {func: Basis(func.name, grid.dimensions, 2)
                          for func in group.funcs}
         else:
+            deriv = dv.Derivative(funcs[0], grid.dimensions[basis_dim])
             basis_map = {func: Basis(func.name,
                                      (grid.dimensions[basis_dim],),
                                      2)
                          for func in group.funcs}
         radius_map = {func: 1 for func in group.funcs}
         # Create a SupportRegion
-        support = SupportRegion(basis_map, radius_map)
+        support = SupportRegion(basis_map, radius_map, deriv)
         geometry = DummyGeometry(grid=grid,
                                  interior_mask={origin:
                                                 np.full(grid.shape, True,
@@ -271,16 +276,20 @@ class TestInterpolant:
             f = dv.TimeFunction(name='f', grid=grid, space_order=s_o)
             conditions = (SingleCondition(dv.Eq(f, 0)),)
             group = DummyGroup((f,), conditions)
+            deriv_func = f
         else:
             f = dv.VectorTimeFunction(name='f', grid=grid, space_order=s_o)
             conditions = (SingleCondition(dv.Eq(f[0], 0)),
                           SingleCondition(dv.Eq(f[1], 0)))
             group = DummyGroup((f[0], f[1]), conditions)
+            deriv_func = f[0]
 
         if basis_dim is None:
+            deriv = dv.Derivative(deriv_func, grid.dimensions[0])
             basis_map = {func: Basis(func.name, grid.dimensions, s_o)
                          for func in group.funcs}
         else:
+            deriv = dv.Derivative(deriv_func, grid.dimensions[basis_dim])
             basis_map = {func: Basis(func.name,
                                      (grid.dimensions[basis_dim],),
                                      s_o)
@@ -289,7 +298,7 @@ class TestInterpolant:
         radius_map = {func: s_o//2 for func in group.funcs}
 
         # Create a SupportRegion
-        support = SupportRegion(basis_map, radius_map)
+        support = SupportRegion(basis_map, radius_map, deriv)
 
         geometry = DummyGeometry(grid=grid,
                                  interior_mask=interior_mask,

--- a/tests/test_substitution.py
+++ b/tests/test_substitution.py
@@ -195,7 +195,7 @@ class TestSubstitution:
 
         substitution = Substitution(deriv, group, basis_map, 'expand', skin)
 
-        wnames = [f.name for f in substitution.wfuncs]
+        wnames = [f.name for f in substitution.weight_map.values()]
         path = os.path.dirname(os.path.abspath(__file__))
         fname = path + '/results/substitution_test_results/' \
             + 'create_weight_function/' + func_type + deriv_type + '.dat'
@@ -220,8 +220,8 @@ class TestSubstitution:
         subs_y = Substitution(group.funcs[1].dy, group, basis_map,
                               'expand', skin)
 
-        wnames_x = [f.name for f in subs_x.wfuncs]
-        wnames_y = [f.name for f in subs_y.wfuncs]
+        wnames_x = [f.name for f in subs_x.weight_map.values()]
+        wnames_y = [f.name for f in subs_y.weight_map.values()]
 
         # These two sets of names should have no overlap (no reused names)
 
@@ -287,4 +287,5 @@ class TestSubstitution:
         expected manner
         """
         subs = weights_test_setup(use_x_derivs=True)
-        assert False
+        # TODO: finish this test
+        # assert False

--- a/tests/test_substitution.py
+++ b/tests/test_substitution.py
@@ -16,7 +16,7 @@ from schism.finite_differences.substitution import Substitution
 from schism import BoundaryGeometry, BoundaryConditions
 
 
-def weights_test_setup():
+def weights_test_setup(use_x_derivs=False):
     """Perform setup for the weight tests"""
     # Load the flat 2D sdf
     sdf = read_sdf('horizontal', 2)
@@ -24,8 +24,12 @@ def weights_test_setup():
     bg = BoundaryGeometry(sdf)
     grid = bg.grid
     f = dv.TimeFunction(name='f', grid=grid, space_order=4)
-    # Deriv will be dy2
-    deriv = f.dy2
+    if use_x_derivs:
+        # Use a cross-derivative
+        deriv = f.dxdy
+    else:
+        # Use 2nd derivative wrt y
+        deriv = f.dy2
     # Pressure free-surface bcs
     bcs = BoundaryConditions([dv.Eq(f, 0),
                               dv.Eq(f.dx2+f.dx2, 0),
@@ -276,3 +280,11 @@ class TestSubstitution:
             + '+ f(t, x + 2*h_x, y + h_y)*w_f_f_dy2_2_1(x, y)'
 
         assert str(subs.expr) == ans
+
+    def test_x_derivatives(self):
+        """
+        Check that cross-derivatives produce substitutions in the
+        expected manner
+        """
+        subs = weights_test_setup(use_x_derivs=True)
+        assert False

--- a/tests/test_substitution.py
+++ b/tests/test_substitution.py
@@ -281,11 +281,10 @@ class TestSubstitution:
 
         assert str(subs.expr) == ans
 
-    def test_x_derivatives(self):
+    def test_x_deriv_rhs(self):
         """
-        Check that cross-derivatives produce substitutions in the
-        expected manner
+        Check that cross-derivatives produce substitutions with the
+        correct number of terms in the expression.
         """
         subs = weights_test_setup(use_x_derivs=True)
-        # TODO: finish this test
-        # assert False
+        assert len(set(subs.weight_map.keys())) == 25

--- a/tests/test_support.py
+++ b/tests/test_support.py
@@ -30,8 +30,10 @@ class TestSupport:
         basis_map = {f: basis}
         # Create the radius map (several radii to test)
         radius_map = {f: radius}
+
+        deriv = dv.Derivative(f, grid.dimensions[selected])
         # Create the support region
-        sr = SupportRegion(basis_map, radius_map)
+        sr = SupportRegion(basis_map, radius_map, deriv)
 
         # Check the footprint
         # Check that it has a length equal to 1+2*radius
@@ -66,7 +68,7 @@ class TestSupport:
             basis_map[v[dim]] = Basis('v_'+str(dim), grid.dimensions, s_o)
             radius_map[v[dim]] = s_o//2 + inc
         # Create the support region
-        sr = SupportRegion(basis_map, radius_map)
+        sr = SupportRegion(basis_map, radius_map, v[0].dx)
 
         for dim in range(ndims):
             fp = sr.footprint_map[v[dim]]
@@ -95,13 +97,13 @@ class TestSupport:
 
         radius_map = {f: f.space_order//2, g: g.space_order//2}
 
-        sr = SupportRegion(basis_map, radius_map)
+        sr = SupportRegion(basis_map, radius_map, f.dx)
 
         for dim in range(2):
-            assert np.amin(sr.footprint_map[f]) == -s_o//2
-            assert np.amax(sr.footprint_map[f]) == s_o//2
-            assert np.amin(sr.footprint_map[g]) == -1-s_o//2
-            assert np.amax(sr.footprint_map[g]) == 1+s_o//2
+            assert np.amin(sr.footprint_map[f][dim]) == -s_o//2
+            assert np.amax(sr.footprint_map[f][dim]) == s_o//2
+            assert np.amin(sr.footprint_map[g][dim]) == -1-s_o//2
+            assert np.amax(sr.footprint_map[g][dim]) == 1+s_o//2
 
     def test_expand_radius(self):
         """
@@ -118,8 +120,8 @@ class TestSupport:
         radius_map = {f: f.space_order//2, g: g.space_order//2}
         larger_radius_map = {f: 1+f.space_order//2, g: 1+g.space_order//2}
 
-        support = SupportRegion(basis_map, radius_map)
-        large_support = SupportRegion(basis_map, larger_radius_map)
+        support = SupportRegion(basis_map, radius_map, f.dx)
+        large_support = SupportRegion(basis_map, larger_radius_map, f.dx)
 
         expanded = support.expand_radius(1)
 


### PR DESCRIPTION
Cross-derivative stencils used to throw an error due to the interior stencil using points not present in the extrapolation support region. This patches that issue.